### PR TITLE
Better UI for map request cards

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -59,6 +59,7 @@ app.get("/data", async (_req: Request, res: Response) => {
       const sortedData = sortByDate(data, "created_at");
 
       const response = {
+        mapboxAccessToken: MAPBOX_ACCESS_TOKEN,
         offlineMaps: sortedData,
         offlineMapsUri: OFFLINE_MAPS_URI,
       };

--- a/components/MapDashboard/MiniMap.vue
+++ b/components/MapDashboard/MiniMap.vue
@@ -1,0 +1,82 @@
+<template>
+    <div ref="map" style="width: 100%; height: 200px;"></div>
+  </template>
+  
+  <script>
+  import mapboxgl from 'mapbox-gl';
+  
+  export default {
+    props: ['mapboxAccessToken', 'bounds'],
+    mounted() {
+      mapboxgl.accessToken = this.mapboxAccessToken;
+
+      const boundsArray = this.bounds.split(',').map(Number).reduce((result, value, index, array) => {
+        if (index % 2 === 0)
+          result.push(array.slice(index, index + 2));
+        return result;
+      }, []);
+    
+      const map = new mapboxgl.Map({
+        container: this.$refs.map,
+        style: 'mapbox://styles/mapbox/streets-v12',
+        center: [(boundsArray[0][0] + boundsArray[1][0]) / 2, (boundsArray[0][1] + boundsArray[1][1]) / 2],
+        zoom: 4,
+        interactive: false
+      });
+  
+      map.on('load', () => {
+
+        map.addLayer({
+          id: 'bounding-box',
+          type: 'fill',
+          source: {
+            type: 'geojson',
+            data: {
+              type: 'Feature',
+              geometry: {
+                type: 'Polygon',
+                coordinates: [[
+                  [boundsArray[0][0], boundsArray[0][1]],
+                  [boundsArray[0][0], boundsArray[1][1]],
+                  [boundsArray[1][0], boundsArray[1][1]],
+                  [boundsArray[1][0], boundsArray[0][1]],
+                  [boundsArray[0][0], boundsArray[0][1]]
+                ]]
+              }
+            }
+          },
+          paint: {
+            'fill-color': '#3BB2D0',
+            'fill-opacity': 0.4
+          }
+        });
+
+        map.addLayer({
+          id: 'bounding-box-border',
+          type: 'line',
+          source: {
+            type: 'geojson',
+            data: {
+              type: 'Feature',
+              geometry: {
+                type: 'Polygon',
+                coordinates: [[
+                  [boundsArray[0][0], boundsArray[0][1]],
+                  [boundsArray[0][0], boundsArray[1][1]],
+                  [boundsArray[1][0], boundsArray[1][1]],
+                  [boundsArray[1][0], boundsArray[0][1]],
+                  [boundsArray[0][0], boundsArray[0][1]]
+                ]]
+              }
+            }
+          },
+          paint: {
+            'line-color': '#3BB2D0',
+            'line-width': 2,
+            'line-dasharray': [2, 2] // This creates a dotted line
+          }
+        });
+      });
+    }
+  };
+  </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,6 +2,7 @@
   <div>
     <MapDashboard 
       v-if="dataFetched" 
+      :mapbox-access-token="mapboxAccessToken"
       :offline-maps="offlineMaps"
       :offline-maps-uri="offlineMapsUri" 
     />
@@ -30,6 +31,7 @@ export default {
       const response = await $axios.$get(`/api/data`, { headers });
       return {
         dataFetched: true,
+        mapboxAccessToken: response.mapboxAccessToken,
         offlineMaps: response.offlineMaps,
         offlineMapsUri: response.offlineMapsUri,
       };


### PR DESCRIPTION
## Goal

Minor improvements to the UI for map request cards on the MapDasboard component.

## Screenshots

![image](https://github.com/ConservationMetrics/map-packer/assets/31662219/12be8a0f-9781-481c-93a3-24ffc6cd7062)

## What I changed

* Added a `MiniMap` Vue component to visualize the map bounds on a (static) map.
* Improved UI layout for the map request card.
* Show filesize as mb, not bytes.