### PR TITLE
Disable submit requests > 275,000 tiles (representing a reasonable estimation of minimum tilesize summing up to 500mb)

### DIFF
--- a/components/GenerateMap/Sidebar.vue
+++ b/components/GenerateMap/Sidebar.vue
@@ -113,14 +113,29 @@
           Estimated number of tiles:
           {{ estimatedTiles.toLocaleString() }}
         </p>
-        <p v-if="estimatedTiles > 100000" class="text-red-600 mt-2">
+        <p v-if="estimatedTiles > 100000 && estimatedTiles < 512000" class="text-red-600 mt-2">
           <span class="font-bold">Warning:</span> You are requesting over 100,000 tiles.
           Note that this will generate a very large offline map file.
           Please also make sure you will not exceed your tile quota for the map style API, or run into unexpected costs.
         </p>
         </div>
 
-        <button type="submit" class="submit-button">Submit Request</button>
+        <!-- Show warning if estimated tiles exceed limit -->
+        <!-- We want to set a 500 megabytes limit for e.g. optimal functionality in Mapeo Mobile. -->
+        <!-- It's not possible to estimate the exact size of a tile, so we use a rough estimate -->
+        <!-- of 1024 bytes per tile (512px). This is a very rough estimate and should be used as a guideline. -->
+        <!-- 500 megabytes = 500 x 1024 KB = 512,000 KB -->
+        <div v-if="estimatedTiles > 512000" class="text-red-600 mt-2">
+          <span class="font-bold">Warning:</span> You are requesting over 512,000 tiles.
+          This exceeds the permitted number of tiles. Please reduce the bounding box or zoom level.
+        </div>
+
+        <button 
+          type="submit" 
+          :disabled="estimatedTiles > 512000" 
+          class="submit-button" 
+          :class="{ 'submit-button-disabled': estimatedTiles > 512000 }"
+        >Submit Request</button>
       </form>
 
   </div>
@@ -280,10 +295,21 @@ export default {
     },
     estimatedTiles() {
       return this.estimateNumberOfTiles(this.form.maxZoom, this.form.selectedBounds);
-    }
+    },
   },
   mounted() {
     this.fetchMapStyles();
   },
 };
 </script>
+
+<style>
+.submit-button-disabled {
+  background-color: gray;
+  cursor: not-allowed;
+}
+
+.submit-button-disabled:hover {
+  background-color: darkgray;
+}
+</style>

--- a/components/GenerateMap/Sidebar.vue
+++ b/components/GenerateMap/Sidebar.vue
@@ -106,8 +106,6 @@
         </div>
 
         <!-- Show estimated number of tiles -->
-        <!-- Note that filesize of each tile varies and it's quite tricky to correctly approximate -->
-        <!-- See https://github.com/mapbox/mapbox-gl-native/issues/4258 -->
         <div v-if="form.maxZoom && form.selectedBounds">
         <p class="italic">
           Estimated number of tiles:
@@ -120,21 +118,21 @@
         </p>
         </div>
 
-        <!-- Show warning if estimated tiles exceed limit -->
-        <!-- We want to set a 500 megabytes limit for e.g. optimal functionality in Mapeo Mobile. -->
-        <!-- It's not possible to estimate the exact size of a tile, so we use a rough estimate -->
-        <!-- of 1024 bytes per tile (512px). This is a very rough estimate and should be used as a guideline. -->
-        <!-- 500 megabytes = 500 x 1024 KB = 512,000 KB -->
-        <div v-if="estimatedTiles > 512000" class="text-red-600 mt-2">
-          <span class="font-bold">Warning:</span> You are requesting over 512,000 tiles.
+        <!-- Show warning if estimated tiles exceed limit
+        We want to set a 500 megabytes limit for e.g. optimal functionality in Mapeo Mobile.
+        It's not possible to estimate the exact size of a tile, so we use a reasonable 
+        minimum filesize estimate of 18,137 bytes per tile (512px).
+        500 megabytes = 500,000,000 / 18,137 = 275,679, rounded down to 275,000 -->
+        <div v-if="estimatedTiles > 275000" class="text-red-600 mt-2">
+          <span class="font-bold">Warning:</span> You are requesting over 275,000 tiles.
           This exceeds the permitted number of tiles. Please reduce the bounding box or zoom level.
         </div>
 
         <button 
           type="submit" 
-          :disabled="estimatedTiles > 512000" 
+          :disabled="estimatedTiles > 275000" 
           class="submit-button" 
-          :class="{ 'submit-button-disabled': estimatedTiles > 512000 }"
+          :class="{ 'submit-button-disabled': estimatedTiles > 275000 }"
         >Submit Request</button>
       </form>
 

--- a/components/GenerateMap/Sidebar.vue
+++ b/components/GenerateMap/Sidebar.vue
@@ -111,7 +111,7 @@
           Estimated number of tiles:
           {{ estimatedTiles.toLocaleString() }}
         </p>
-        <p v-if="estimatedTiles > 100000 && estimatedTiles < 512000" class="text-red-600 mt-2">
+        <p v-if="estimatedTiles > 100000 && estimatedTiles < 275000" class="text-red-600 mt-2">
           <span class="font-bold">Warning:</span> You are requesting over 100,000 tiles.
           Note that this will generate a very large offline map file.
           Please also make sure you will not exceed your tile quota for the map style API, or run into unexpected costs.
@@ -300,14 +300,3 @@ export default {
   },
 };
 </script>
-
-<style>
-.submit-button-disabled {
-  background-color: gray;
-  cursor: not-allowed;
-}
-
-.submit-button-disabled:hover {
-  background-color: darkgray;
-}
-</style>

--- a/components/GenerateMap/style.css
+++ b/components/GenerateMap/style.css
@@ -125,6 +125,15 @@
   .submit-button:hover {
     background-color: #45a049;
   }
+
+  .submit-button-disabled {
+    background-color: gray;
+    cursor: not-allowed;
+  }
+
+  .submit-button-disabled:hover {
+    background-color: darkgray;
+  }
   
   /* Request successfully submitted modal */
   .overlay {


### PR DESCRIPTION
Closes #12.

## Goal

While it is not possible to determine an actual filesize of an offline map package in advance, we can set a reasonable limit based on a minimum possible filesize of a 512px JPG, and a desired maximum MBTiles filesize limit of 500mb.

We can try this out with a "blank" tile (all white). I generated a few with `mapgl-tile-renderer` by downloading Planet tiles outside of the NICFI (tropical forest) AOI. The binary content stored in the MBTiles SQLite table for one such tile adds up to 18,963 bytes.

I prompted ChatGPT to run a similar estimation, arriving at a similar number:

```python
import os
from PIL import Image

# Load the image
img = Image.open("/mnt/data/A_simple,_solid_color_image_of_a_light_blue_square.png")

# Convert to JPG with high compression (low quality setting)
compressed_image_path = "/mnt/data/compressed_high_compression.jpg"
img.save(compressed_image_path, 'JPEG', quality=5)  # Set quality low to maximize compression

# Check the file size
compressed_image_size = os.path.getsize(compressed_image_path)
compressed_image_size
```
> Result: 18,137 bytes

Hence, we can set a tile limit in the following way (500mb in bytes divided by one minimum size JPG): 
```
500,000,000 / 18,137 = 275679
```

So, we round that down to 275,000, and use that as the threshold.

## Screenshots

![image](https://github.com/ConservationMetrics/map-packer/assets/31662219/1c33cecd-88a3-48b7-9914-14a78cd41afd)

## What I changed

Disable (and change color of) submit button if `estimatedTiles` > 275000.
