### PR TITLE
Add ability to delete or resubmit a failed map request

### DIFF
--- a/api/database/dbOperations.ts
+++ b/api/database/dbOperations.ts
@@ -103,6 +103,34 @@ export const insertDataIntoTable = async (
   });
 };
 
+export async function updateDatabaseMapRequest(db: any, tableName: string, id: number | void | null, data: any) {
+  if (id === null || id === undefined || !Number.isInteger(id)) {
+    throw new Error('Invalid ID provided for updating database.');
+  }
+
+  const columns = Object.keys(data).map((key, index) => `${key} = $${index + 1}`).join(', ');
+  const values = Object.values(data);
+  values.push(id);
+
+  const query = `
+    UPDATE ${tableName}
+    SET ${columns}
+    WHERE id = $${values.length}
+  `;
+
+  return new Promise<void>((resolve, reject) => {
+    db.query(query, values, (err: Error) => {
+      if (err) {
+        console.error(`Error updating record ${id} in table ${tableName}: ${err.message}`);
+        reject(err);
+      } else {
+        console.log(`Record ${id} in table ${tableName} updated.`);
+        resolve();
+      }
+    });
+  });
+}
+
 export async function updateDatabaseWithError(db: any, tableName: string, id: number | void | null, errorMessage: string) {
   if (id === null || id === undefined || !Number.isInteger(id)) {
     throw new Error('Invalid ID provided for updating error message.');

--- a/api/database/dbOperations.ts
+++ b/api/database/dbOperations.ts
@@ -110,7 +110,7 @@ export async function updateDatabaseWithError(db: any, tableName: string, id: nu
 
   const query = `
     UPDATE ${tableName}
-    SET status = 'FAILED', errormessage = $1
+    SET status = 'FAILED', error_message = $1
     WHERE id = $2
   `;
 

--- a/api/index.ts
+++ b/api/index.ts
@@ -164,9 +164,16 @@ app.post("/maprequest", async (req: Request, res: Response) => {
       delete data.requestId;
       await updateDatabaseMapRequest(db, DB_TABLE, requestId, data);
     }
+    // If it's a delete request, update the data in the database with STATUS = "PENDING DELETION"
+    // Delete requests are handled further by mapgl-tile-renderer
+    else if (req.body.type === "delete_request") {
+      console.log("Updating data in database...");
+      await updateDatabaseMapRequest(db, DB_TABLE, requestId, { status: "PENDING DELETION" });
+    } else {
+      throw new Error("Invalid request type");
+    }
 
     // Publish message to Azure Storage Queue
-    // Delete requests are handled entirely by mapgl-tile-renderer
     if (ASQ_QUEUE_NAME) {
       console.log(`Publishing message to queue: ${ASQ_QUEUE_NAME}`);
       await publishToAzureStorageQueue(ASQ_QUEUE_NAME, req.body, requestId);

--- a/api/messageQueue/azure.ts
+++ b/api/messageQueue/azure.ts
@@ -6,6 +6,7 @@ export async function publishToAzureStorageQueue(
     type: any;
     bounds: any; 
     filename: any;
+    file_location: any;
     mapbox_style: any;
     min_zoom: any; 
     max_zoom: any; 
@@ -40,12 +41,12 @@ export async function publishToAzureStorageQueue(
     ...(message.planet_monthly_visual && { monthYear: message.planet_monthly_visual }),
     ...(message.openstreetmap && { openStreetMap: message.openstreetmap }),
     ...(message.filename && { outputFilename: message.filename}),
-    ...(process.env.OFFLINE_MAPS_PATH && { outputDir: process.env.OFFLINE_MAPS_PATH })
+    ...(message.file_location ? { outputDir: message.file_location } : (process.env.OFFLINE_MAPS_PATH && { outputDir: process.env.OFFLINE_MAPS_PATH }))
   };
 
-  if (transformedMessage.style.includes("mapbox")) {
+  if (transformedMessage.style && transformedMessage.style.includes("mapbox")) {
     transformedMessage.apiKey = process.env.MAPBOX_ACCESS_TOKEN;
-  } else if (transformedMessage.style === "planet") {
+  } else if (transformedMessage.style && transformedMessage.style === "planet") {
     transformedMessage.apiKey = process.env.VUE_APP_PLANET_API_KEY;
   }
 

--- a/api/messageQueue/azure.ts
+++ b/api/messageQueue/azure.ts
@@ -3,6 +3,7 @@ import { QueueServiceClient } from "@azure/storage-queue";
 export async function publishToAzureStorageQueue(
   queueName: string,
   message: { 
+    type: any;
     bounds: any; 
     filename: any;
     mapbox_style: any;
@@ -30,6 +31,7 @@ export async function publishToAzureStorageQueue(
   // Transform the message object to match the inputs expected by mapgl-tile-renderer
   const transformedMessage = {
     requestId: requestId,
+    ...(message.type && { type: message.type }),
     ...(message.bounds && { bounds: message.bounds }),
     ...(message.style && { style: message.style }),
     ...(message.mapbox_style && { mapboxStyle: message.mapbox_style }),

--- a/components/GenerateMap.vue
+++ b/components/GenerateMap.vue
@@ -33,6 +33,7 @@ import Sidebar from "@/components/GenerateMap/Sidebar.vue";
 import MapNavigation from "@/components/GenerateMap/MapNavigation.vue";
 import MapCanvas from "@/components/GenerateMap/MapCanvas.vue";
 import style from '@/components/GenerateMap/style.css';
+import overlayModal from '@/components/overlay.css';
 
 export default {
   components: { MapCanvas, Sidebar, MapNavigation },
@@ -55,7 +56,7 @@ export default {
   },
   methods: {
     handleFormSubmit(formData) {
-      this.$emit("formSubmitted", formData);
+      this.$emit("handleMapRequest", formData);
       this.showModal = true;
       setTimeout(() => {
         this.$router.push('/');
@@ -73,7 +74,7 @@ export default {
   },
   computed: {
     style() {
-      return style;
+      return { ...style, ...overlayModal };
     },
   }
 };

--- a/components/GenerateMap/Sidebar.vue
+++ b/components/GenerateMap/Sidebar.vue
@@ -277,6 +277,8 @@ export default {
         formToSubmit.mapboxStyle = this.form.selectedStyle.replace('mapbox://styles/', '');
       }
 
+      formToSubmit.type = "new_request";
+
       this.$emit("formSubmitted", formToSubmit);
     },
   },

--- a/components/GenerateMap/style.css
+++ b/components/GenerateMap/style.css
@@ -134,33 +134,3 @@
   .submit-button-disabled:hover {
     background-color: darkgray;
   }
-  
-  /* Request successfully submitted modal */
-  .overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.75);
-    z-index: 1040;
-  }
-  
-  .modal {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    background-color: white;
-    padding: 20px;
-    z-index: 1050;
-    border-radius: 8px;
-    box-shadow: 0 4px 6px rgba(0,0,0,.1);
-    text-align: center;
-    animation: fadeIn 0.5s ease;
-  }
-  
-  @keyframes fadeIn {
-    from { opacity: 0; }
-    to { opacity: 1; }
-  }

--- a/components/MapDashboard.vue
+++ b/components/MapDashboard.vue
@@ -60,6 +60,14 @@
             }}
           </p>
         </div>
+        <div v-if="map.error_message" class="flex mb-2">
+            <button
+              class="copy-button bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded transition duration-200 ease-in-out"
+              @click="resubmitMapRequest(map.id)"
+            >
+              Resubmit
+            </button>
+        </div>          
         <div v-if="map.file_location && offlineMapsUri" class="flex mb-2">
           <a
             :href="`${offlineMapsUri}/${map.filename}`"
@@ -106,12 +114,17 @@
         </p>
       </div>
     </div>
+    <div v-if="showModal" class="overlay"></div>
+    <div v-if="showModal" class="modal">
+      Offline map request successfully resubmitted!
+    </div>
   </div>
 </template>
 
 <script>
 import MiniMap from "@/components/MapDashboard/MiniMap.vue";
 import { copyLink } from "@/src/utils.ts";
+import overlayModal from '@/components/overlay.css';
 
 export default {
   components: { MiniMap },
@@ -124,11 +137,33 @@ export default {
     return {
       refreshKey: 0,
       tooltipId: null,
+      showModal: false,
     };
   },
   methods: {
+    calculateDuration(start, end) {
+      const startDate = new Date(start);
+      const endDate = new Date(end);
+      const duration = endDate - startDate;
+      const hours = Math.floor(duration / (1000 * 60 * 60));
+      const minutes = Math.floor((duration / (1000 * 60)) % 60);
+      const seconds = Math.floor((duration / 1000) % 60);
+      return `${hours}h ${minutes}m ${seconds}s`;
+    },
+    copyLinkToClipboard(link, id) {
+      copyLink(link)
+        .then(() => {
+          this.tooltipId = id;
+          setTimeout(() => {
+            this.tooltipId = null;
+          }, 1500);
+        })
+        .catch((err) => {
+          console.error("Failed to copy:", err);
+        });
+    },
     deleteMap(id) {
-      let confirmation = window.confirm("Are you sure you want to delete this map? This action cannot be undone.");
+      let confirmation = window.confirm("Are you sure you want to delete this offline map? This action cannot be undone.");
 
       if (confirmation) {
         const map = this.offlineMaps.find(m => m.id === id);
@@ -138,7 +173,7 @@ export default {
             outputFilename: map.filename,
             outputDir: map.file_location
           };
-          this.$emit('deleteMap', message);
+          this.$emit('handleMapRequest', message);
         }
       }
     },
@@ -173,28 +208,42 @@ export default {
           return "font-semibold text-gray-600";
       }
     },
-    calculateDuration(start, end) {
-      const startDate = new Date(start);
-      const endDate = new Date(end);
-      const duration = endDate - startDate;
-      const hours = Math.floor(duration / (1000 * 60 * 60));
-      const minutes = Math.floor((duration / (1000 * 60)) % 60);
-      const seconds = Math.floor((duration / 1000) % 60);
-      return `${hours}h ${minutes}m ${seconds}s`;
-    },
-    copyLinkToClipboard(link, id) {
-      copyLink(link)
-        .then(() => {
-          this.tooltipId = id;
-          setTimeout(() => {
-            this.tooltipId = null;
-          }, 1500);
-        })
-        .catch((err) => {
-          console.error("Failed to copy:", err);
-        });
+    resubmitMapRequest(id) {
+      const map = this.offlineMaps.find(m => m.id === id);
+      if (map) {
+        const message = {
+          type: "resubmit_request",
+          title: map.title,
+          filename: map.filename,
+          status: "PENDING",
+          error_message: null,
+          description: map.description,
+          min_zoom: map.min_zoom,
+          max_zoom: map.max_zoom,
+          mapbox_style: map.mapbox_style,
+          planet_monthly_visual: map.planet_monthly_visual,
+          bounds: map.bounds,
+          style: map.style,
+          openstreetmap: map.openstreetmap,
+          number_of_tiles: map.number_of_tiles,
+          created_at: new Date(),
+          requestId: map.id,
+        };
+        this.$emit('handleMapRequest', message);
+        this.showModal = true;
+        // wait 3 seconds and refresh the page content
+        setTimeout(() => {
+          this.showModal = false;
+          location.reload();
+        }, 3000);
+      }
     },
   },
+  computed: {
+    style() {
+      return { ...overlayModal };
+    },
+  }
 };
 </script>
 

--- a/components/MapDashboard.vue
+++ b/components/MapDashboard.vue
@@ -19,7 +19,7 @@
         class="card relative bg-white border border-gray-300 rounded-lg shadow-lg p-6 flex flex-col"
       >
         <button
-          class="delete absolute top-2 right-2 text-red-500 hover:text-red-300 font-bold py-1 px-1 cursor-pointer"
+          class="delete absolute top-2 right-2 text-red-500 hover:text-red-700 font-bold py-1 px-1 cursor-pointer"
           @click="deleteMap(map.id)"
         >X</button>
         <h2 class="text-2xl font-bold text-gray-800 mb-2" v-if="map.title">
@@ -116,7 +116,7 @@
     </div>
     <div v-if="showModal" class="overlay"></div>
     <div v-if="showModal" class="modal">
-      Offline map request successfully resubmitted!
+      {{ modalMessage }}
     </div>
   </div>
 </template>
@@ -138,6 +138,7 @@ export default {
       refreshKey: 0,
       tooltipId: null,
       showModal: false,
+      modalMessage: '',
     };
   },
   methods: {
@@ -169,11 +170,19 @@ export default {
         const map = this.offlineMaps.find(m => m.id === id);
         if (map) {
           const message = {
+            type: "delete_request",
             requestId: map.id,
-            outputFilename: map.filename,
-            outputDir: map.file_location
+            filename: map.filename,
+            file_location: map.file_location
           };
           this.$emit('handleMapRequest', message);
+          this.modalMessage = 'Offline map request (and associated files) deleted!';
+          this.showModal = true;
+          // wait 3 seconds and refresh the page content
+          setTimeout(() => {
+            this.showModal = false;
+            location.reload();
+          }, 3000);
         }
       }
     },
@@ -199,6 +208,8 @@ export default {
     formatStatusColor(status) {
       switch (status) {
         case "FAILED":
+          return "font-semibold text-red-500";
+        case "PENDING DELETION":
           return "font-semibold text-red-500";
         case "PENDING":
           return "font-semibold text-yellow-500";
@@ -230,6 +241,7 @@ export default {
           requestId: map.id,
         };
         this.$emit('handleMapRequest', message);
+        this.modalMessage = 'Offline map request successfully resubmitted!';
         this.showModal = true;
         // wait 3 seconds and refresh the page content
         setTimeout(() => {

--- a/components/MapDashboard.vue
+++ b/components/MapDashboard.vue
@@ -16,8 +16,12 @@
       <div
         v-for="map in offlineMaps"
         :key="map.id"
-        class="card bg-white border border-gray-300 rounded-lg shadow-lg p-6 flex flex-col"
+        class="card relative bg-white border border-gray-300 rounded-lg shadow-lg p-6 flex flex-col"
       >
+        <button
+          class="delete absolute top-2 right-2 text-red-500 hover:text-red-300 font-bold py-1 px-1 cursor-pointer"
+          @click="deleteMap(map.id)"
+        >X</button>
         <h2 class="text-2xl font-bold text-gray-800 mb-2" v-if="map.title">
           {{ map.title }}
         </h2>
@@ -123,6 +127,21 @@ export default {
     };
   },
   methods: {
+    deleteMap(id) {
+      let confirmation = window.confirm("Are you sure you want to delete this map? This action cannot be undone.");
+
+      if (confirmation) {
+        const map = this.offlineMaps.find(m => m.id === id);
+        if (map) {
+          const message = {
+            requestId: map.id,
+            outputFilename: map.filename,
+            outputDir: map.file_location
+          };
+          this.$emit('deleteMap', message);
+        }
+      }
+    },
     formatFilesize(size) {
       return (size / 1024 / 1024).toFixed(2);
     },
@@ -180,11 +199,22 @@ export default {
 </script>
 
 <style scoped>
+.card {
+  position: relative;
+}
+
 .tooltip {
   position: absolute;
   margin-left: 10px;
   white-space: nowrap;
   transform: translateX(150%) translateY(-110%);
+  z-index: 10;
+}
+
+.delete {
+  position: absolute;
+  right: 10px;
+  top: 0px;
   z-index: 10;
 }
 </style>

--- a/components/overlay.css
+++ b/components/overlay.css
@@ -1,0 +1,31 @@
+  /* Request successfully submitted modal */
+  .overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.75);
+    z-index: 1040;
+  }
+  
+  .modal {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background-color: white;
+    padding: 20px;
+    z-index: 1050;
+    border-radius: 8px;
+    box-shadow: 0 4px 6px rgba(0,0,0,.1);
+    text-align: center;
+    animation: fadeIn 0.5s ease;
+  }
+  
+  @keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
+  

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,6 +2,7 @@
   <div>
     <MapDashboard 
       v-if="dataFetched" 
+      @deleteMap="deleteMap"
       :mapbox-access-token="mapboxAccessToken"
       :offline-maps="offlineMaps"
       :offline-maps-uri="offlineMapsUri" 
@@ -19,6 +20,11 @@ export default {
     };
   },
   components: { MapDashboard },
+  methods: {
+    async deleteMap(message) {
+
+    },
+  },
   async asyncData({ $axios, app }) {
     // Set up the headers for the request
     let headers = {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,10 +2,10 @@
   <div>
     <MapDashboard 
       v-if="dataFetched" 
-      @deleteMap="deleteMap"
       :mapbox-access-token="mapboxAccessToken"
       :offline-maps="offlineMaps"
       :offline-maps-uri="offlineMapsUri" 
+      @handleMapRequest="handleMapRequest"
     />
   </div>
 </template>
@@ -20,10 +20,22 @@ export default {
     };
   },
   components: { MapDashboard },
+  data() {
+    return {
+      headers: {
+        "x-api-key": this.$config.apiKey.replace(/['"]+/g, ""),
+        "x-auth-strategy": this.$auth.strategy.name,
+      },
+    };
+  },
   methods: {
-    async deleteMap(message) {
-
-    },
+    async handleMapRequest(message) {
+      try {
+          await this.$axios.$post('/api/maprequest', message, { headers: this.headers });
+        } catch (error) {
+          console.error("Error submitting request data:", error);
+        }
+    }
   },
   async asyncData({ $axios, app }) {
     // Set up the headers for the request

--- a/pages/map.vue
+++ b/pages/map.vue
@@ -2,7 +2,7 @@
   <div>
     <GenerateMap
       v-if="dataFetched"
-      @formSubmitted="handleFormSubmit"
+      @handleMapRequest="handleMapRequest"
       :availableMapStyles="availableMapStyles"
       :mapboxAccessToken="mapboxAccessToken"
       :mapLatitude="mapLatitude"
@@ -31,9 +31,9 @@ export default {
     };
   },
   methods: {
-    async handleFormSubmit(formData) {
+    async handleMapRequest(formData) {
         // Transform formData to match the expected database table schema
-        const transformedData = {
+        const transformedMessage = {
           type: "new_request",
           title: formData.title,
           filename: formData.title.replace(/\W+/g, '_'),
@@ -51,9 +51,9 @@ export default {
         };
       
         try {
-          await this.$axios.$post('/api/newmaprequest', transformedData, { headers: this.headers });
+          await this.$axios.$post('/api/maprequest', transformedMessage, { headers: this.headers });
         } catch (error) {
-          console.error("Error submitting form data:", error);
+          console.error("Error submitting request data:", error);
         }
     },
   },

--- a/pages/map.vue
+++ b/pages/map.vue
@@ -34,6 +34,7 @@ export default {
     async handleFormSubmit(formData) {
         // Transform formData to match the expected database table schema
         const transformedData = {
+          type: "new_request",
           title: formData.title,
           filename: formData.title.replace(/\W+/g, '_'),
           status: "PENDING",


### PR DESCRIPTION
## Goal

Closes #10 and #21. This PR makes it possible to resubmit and delete a map request.

## What I changed

* Expanded the `/maprequest` (formerly `/newmaprequest`) endpoint to take a different action depending on the `type` of request (new_request, resubmit_request, delete_request). map-packer will update the database in each case with respective information and publish the message to a queue, to be further handled downstream.
* Added a new function `updateDatabaseMapRequest` used by new_request and resubmit_request cases, where we want to update one or more columns of an existing request.
* On the front end, added a resubmit and delete button to map cards on `MapDashboard` component; both trigger a popup to confirm the action, and now utilize a "request successfully submitted" overlay that was previously only used on the `GenerateMap` component.