### PR TITLE
Add QR code option to access an offline map

### DIFF
--- a/components/MapDashboard.vue
+++ b/components/MapDashboard.vue
@@ -74,6 +74,11 @@
             class="download-button bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded transition duration-200 ease-in-out mr-4"
             >Download</a
           >
+          <button
+            class="qr-code bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded transition duration-200 ease-in-out mr-4"
+            @click="toggleQRCode(map.id)"
+            >QR
+          </button>
           <div>
             <button
               class="copy-button bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded transition duration-200 ease-in-out"
@@ -88,7 +93,10 @@
               Copied!
             </div>
           </div>
-        </div>          
+        </div>
+        <div v-if="showQRCodeId === map.id" class="flex mb-2">
+          <QRCode :value="`${offlineMapsUri}/${map.filename}`" size="300" />
+        </div>        
         <div class="space-y-2 flex-grow" v-if="map.status !== 'PENDING'">
             <h3 class="italic text-lg text-gray-600">Metadata</h3>
             <p v-if="map.work_begun && map.work_ended">
@@ -122,12 +130,14 @@
 </template>
 
 <script>
+import QRCode from 'qrcode.vue';
+
 import MiniMap from "@/components/MapDashboard/MiniMap.vue";
 import { copyLink } from "@/src/utils.ts";
 import overlayModal from '@/components/overlay.css';
 
 export default {
-  components: { MiniMap },
+  components: { MiniMap, QRCode },
   props: [
     "mapboxAccessToken",
     "offlineMaps",
@@ -137,6 +147,7 @@ export default {
     return {
       refreshKey: 0,
       tooltipId: null,
+      showQRCodeId: null,
       showModal: false,
       modalMessage: '',
     };
@@ -250,6 +261,9 @@ export default {
         }, 3000);
       }
     },
+    toggleQRCode(id) {
+      this.showQRCodeId = this.showQRCodeId === id ? null : id;
+    },
   },
   computed: {
     style() {
@@ -268,7 +282,7 @@ export default {
   position: absolute;
   margin-left: 10px;
   white-space: nowrap;
-  transform: translateX(150%) translateY(-110%);
+  transform: translateX(10%) translateY(20%);
   z-index: 10;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "mapbox-gl-draw-rectangle-mode": "^1.0.4",
         "nuxt": "^2.17.2",
         "pg": "^8.11.3",
+        "qrcode.vue": "^1.7.0",
         "vue": "^2.7.10",
         "vue-server-renderer": "^2.7.10",
         "vue-slider-component": "^3.2.24",
@@ -7278,13 +7279,28 @@
       }
     },
     "node_modules/buffer": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true,
+      "peer": true,
       "dependencies": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -12986,6 +13002,16 @@
         "vm-browserify": "^1.0.1"
       }
     },
+    "node_modules/node-libs-browser/node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
     "node_modules/node-libs-browser/node_modules/punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -16139,6 +16165,14 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.vue": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/qrcode.vue/-/qrcode.vue-1.7.0.tgz",
+      "integrity": "sha512-R7t6Y3fDDtcU7L4rtqwGUDP9xD64gJhIwpfjhRCTKmBoYF6SS49PIJHRJ048cse6OI7iwTwgyy2C46N9Ygoc6g==",
+      "peerDependencies": {
+        "vue": "^2.0.0"
       }
     },
     "node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "mapbox-gl-draw-rectangle-mode": "^1.0.4",
     "nuxt": "^2.17.2",
     "pg": "^8.11.3",
+    "qrcode.vue": "^1.7.0",
     "vue": "^2.7.10",
     "vue-server-renderer": "^2.7.10",
     "vue-slider-component": "^3.2.24",


### PR DESCRIPTION
## Goal

Per user feedback, this PR adds an option to toggle a QR code for each map request that has a file ready for download.

## Screenshots

![image](https://github.com/ConservationMetrics/map-packer/assets/31662219/ab14e9f5-40c4-4782-9b97-ae9e33e29c44)

## What I changed

* Added the node package `qrcode.vue` to add a QRCode component to the cards for any map requests that have a file to download. By default, the QR code is not shown; the user must click/press the QR code button to show the QR code. Only one QR code is shown on the screen, to avoid somebody accidentally downloading the wrong offline map.