### PR TITLE
Add option to use custom mapbox style

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -146,19 +146,22 @@ app.get("/mapstyle/planet/:year/:month", (req: Request, res: Response) => {
 // API endpoint to POST a request to the db and publish message to queue
 app.post("/maprequest", async (req: Request, res: Response) => {
   let requestId: number | void | null = req.body.requestId;
+  const data = { ...req.body };
+
+  if (data.style ="mapbox-custon") {
+    data.style ="mapbox"
+  }
 
   try {
     // If it's a new request, insert data into the database
     if (req.body.type === "new_request") {
       console.log("Inserting data into database...");
-      const data = { ...req.body };
       delete data.type;
       requestId = await insertDataIntoTable(db, DB_TABLE, data);
     }
     // If it's a resubmit request, update the data in the database
     else if (req.body.type === "resubmit_request") {
       console.log("Updating data in database...");
-      const data = { ...req.body };
       delete data.type;
       delete data.requestId;
       await updateDatabaseMapRequest(db, DB_TABLE, requestId, data);

--- a/api/styles/mapStyles.ts
+++ b/api/styles/mapStyles.ts
@@ -4,6 +4,7 @@ export type MapStyleKey =
   | "bing"
   | "google"
   | "esri"
+  | "mapbox-custom"
   | "mapbox-satellite"
   | "mapbox-streets"
   | "planet";
@@ -104,6 +105,9 @@ export const mapStyles: Record<MapStyleKey, MapStyle> = {
         },
       ],
     },
+  },
+  "mapbox-custom": {
+    name: "Your Mapbox Style"
   },
   "mapbox-satellite": {
     name: "Mapbox Satellite",

--- a/components/GenerateMap.vue
+++ b/components/GenerateMap.vue
@@ -65,13 +65,6 @@ export default {
     updateMapParams(updateObj) {
       let { param, value } = updateObj;
 
-      console.log(param)
-
-      if (param === "Style" && !/^mapbox:\/\/styles\/[^\/]+\/[^\/]+$/.test(value)) {
-        // If the style is not a valid Mapbox style URL, do not update
-        return;
-      }
-
       if (typeof value === "number") {
         value = parseFloat(value.toFixed(6));
       }

--- a/components/GenerateMap.vue
+++ b/components/GenerateMap.vue
@@ -65,6 +65,13 @@ export default {
     updateMapParams(updateObj) {
       let { param, value } = updateObj;
 
+      console.log(param)
+
+      if (param === "Style" && !/^mapbox:\/\/styles\/[^\/]+\/[^\/]+$/.test(value)) {
+        // If the style is not a valid Mapbox style URL, do not update
+        return;
+      }
+
       if (typeof value === "number") {
         value = parseFloat(value.toFixed(6));
       }

--- a/components/GenerateMap/Sidebar.vue
+++ b/components/GenerateMap/Sidebar.vue
@@ -44,6 +44,20 @@
         </select>
       </div>
 
+      <div v-if="selectedStyleKey === 'mapbox-custom'" class="form-group">
+        <label for="customMapboxStyle">Your Mapbox Style URL</label>
+        <input
+          type="text"
+          id="customMapboxStyle"
+          v-model="customMapboxStyleUrl"
+          placeholder="mapbox://styles/user/styleId"
+          class="input-field"
+        />
+        <p v-if="!isValidCustomMapboxStyleUrl" class="text-red-600">
+          Please enter a valid Mapbox style URL.
+        </p>
+      </div>
+
       <div v-if="form.selectedStyle.includes('/api/mapstyle/planet/')">
         <div class="form-group">
           <label for="planetMonthYear"
@@ -174,6 +188,7 @@ export default {
   props: ["availableMapStyles", "mapboxAccessToken", "mapBounds", "mapStyle"],
   data() {
     return {
+      customMapboxStyleUrl: "",
       mapStyles: [],
       form: {
         title: "",
@@ -188,6 +203,12 @@ export default {
   },
   watch: {
     // Watch for changes to the map's style and bounds props
+    customMapboxStyleUrl(newVal) {
+      if (this.isValidCustomMapboxStyleUrl) {
+        // Emit only when a valid custom Mapbox style URL is entered
+        this.$emit("updateMapParams", { param: "Style", value: newVal });
+      }
+    },
     mapBounds(newVal) {
       this.form.selectedBounds = newVal;
     },
@@ -291,6 +312,11 @@ export default {
         );
       }
 
+      // If the selected style is custom-mapbox, include the custom Mapbox Style URL
+      if (this.selectedStyleKey === "mapbox-custom") {
+        formToSubmit.mapboxStyle = this.customMapboxStyleUrl;
+      }
+
       formToSubmit.type = "new_request";
 
       this.$emit("formSubmitted", formToSubmit);
@@ -322,6 +348,9 @@ export default {
         this.form.maxZoom,
         this.form.selectedBounds,
       );
+    },
+    isValidCustomMapboxStyleUrl() {
+      return /^mapbox:\/\/styles\/[^\/]+\/[^\/]+$/.test(this.customMapboxStyleUrl);
     },
   },
   mounted() {


### PR DESCRIPTION
## Goal

To allow the user to add their custom map URL in the GenerateMap view.

## Screenshots

![image](https://github.com/ConservationMetrics/map-packer/assets/31662219/30ef2ef7-6adc-4379-93a6-8b91489fb1e1)

## What I changed

* Added a `mapbox-custom` mapStyle and if selected in the dropdown, show a field to enter a Mapbox URL. The button is disabled if the URL does not meet the regex conditions set in `isValidCustomMapboxStyleUrl`.