### PR TITLE
Implement database pagination and scroll-based loading for MapDashboard

### DIFF
--- a/api/dataProcessing/filterData.ts
+++ b/api/dataProcessing/filterData.ts
@@ -1,7 +1,0 @@
-export function sortByDate<T>(data: T[], dateField: keyof T): T[] {
-  return data.sort((a, b) => {
-    const dateA = new Date(a[dateField] as unknown as string);
-    const dateB = new Date(b[dateField] as unknown as string);
-    return dateB.getTime() - dateA.getTime();
-  });
-}

--- a/api/index.ts
+++ b/api/index.ts
@@ -68,8 +68,8 @@ app.get("/data", async (req: Request, res: Response) => {
       const response = {
         mapboxAccessToken: MAPBOX_ACCESS_TOKEN,
         // Set nextCursor to the last id in the data array
-        // How this works: If there are more rows in the database,
-        //the last row's id will be used as the nextCursor
+        // If there are more rows in the database,
+        // the last row's id will be used as the nextCursor
         // to fetch the next set of rows. If not, nextCursor will be null.
         nextCursor: data.length ? data[data.length - 1].id : null,
         offlineMaps: data,

--- a/api/index.ts
+++ b/api/index.ts
@@ -67,6 +67,10 @@ app.get("/data", async (req: Request, res: Response) => {
     } else {
       const response = {
         mapboxAccessToken: MAPBOX_ACCESS_TOKEN,
+        // Set nextCursor to the last id in the data array
+        // How this works: If there are more rows in the database,
+        //the last row's id will be used as the nextCursor
+        // to fetch the next set of rows. If not, nextCursor will be null.
         nextCursor: data.length ? data[data.length - 1].id : null,
         offlineMaps: data,
         offlineMapsUri: OFFLINE_MAPS_URI,

--- a/components/MapDashboard.vue
+++ b/components/MapDashboard.vue
@@ -218,9 +218,7 @@ export default {
   },
   data() {
     return {
-      currentPage: 1,
       dropdownOpen: false,
-      itemsPerPage: 6,
       refreshKey: 0,
       tooltipId: null,
       showQRCodeId: null,

--- a/components/MapDashboard.vue
+++ b/components/MapDashboard.vue
@@ -1,36 +1,52 @@
 <template>
   <div class="mt-4 mx-auto w-full max-w-6xl px-4">
     <div class="flex justify-end space-x-4 mb-4">
-    <div class="relative inline-block text-left">
-      <div>
-        <button @click="toggleDropdown" class="inline-flex justify-center w-full rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none">
-          {{ currentLocaleName }}
-          <svg class="-mr-1 ml-2 h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-            <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
-          </svg>
-        </button>
-      </div>
-      <div v-if="dropdownOpen" class="origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50">
-        <div class="py-1">
-          <a
-            href="#"
-            v-for="locale in availableLocales"
-            :key="locale.code"
-            class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-            @click.prevent.stop="changeLocale(locale.code)"
+      <div class="relative inline-block text-left">
+        <div>
+          <button
+            @click="toggleDropdown"
+            class="inline-flex justify-center w-full rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none"
           >
-            {{ locale.name }}
-          </a>
+            {{ currentLocaleName }}
+            <svg
+              class="-mr-1 ml-2 h-5 w-5"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          v-if="dropdownOpen"
+          class="origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50"
+        >
+          <div class="py-1">
+            <a
+              href="#"
+              v-for="locale in availableLocales"
+              :key="locale.code"
+              class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+              @click.prevent.stop="changeLocale(locale.code)"
+            >
+              {{ locale.name }}
+            </a>
+          </div>
         </div>
       </div>
+      <nuxt-link
+        :to="localePath('map')"
+        class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded cursor-pointer transition-colors duration-200 hidden md:block"
+      >
+        + {{ $t("generateMap") }}
+      </nuxt-link>
     </div>
-    <nuxt-link
-      :to="localePath('map')"
-      class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded cursor-pointer transition-colors duration-200 hidden md:block"
-    >
-      + {{ $t("generateMap") }}
-    </nuxt-link>
-  </div>
     <h1 class="text-4xl font-bold text-gray-800 mb-8 text-center">
       {{ $t("availableOfflineMaps") }}
     </h1>
@@ -39,9 +55,9 @@
       class="block bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded cursor-pointer transition-colors duration-200 text-center mb-8 md:hidden"
       >+ {{ $t("generateMap") }}</nuxt-link
     >
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
       <div
-        v-for="map in offlineMaps"
+        v-for="map in paginatedOfflineMaps"
         :key="map.id"
         class="card relative bg-white border border-gray-300 rounded-lg shadow-lg p-6 flex flex-col"
       >
@@ -188,17 +204,23 @@
 
 <script>
 import QRCode from "qrcode.vue";
-
 import MiniMap from "@/components/MapDashboard/MiniMap.vue";
 import { copyLink } from "@/src/utils.ts";
 import overlayModal from "@/components/overlay.css";
 
 export default {
   components: { MiniMap, QRCode },
-  props: ["mapboxAccessToken", "offlineMaps", "offlineMapsUri"],
+  props: {
+    mapboxAccessToken: String,
+    offlineMaps: Array,
+    offlineMapsUri: String,
+    nextCursor: Number,
+  },
   data() {
     return {
+      currentPage: 1,
       dropdownOpen: false,
+      itemsPerPage: 6,
       refreshKey: 0,
       tooltipId: null,
       showQRCodeId: null,
@@ -290,6 +312,14 @@ export default {
           return "font-semibold text-gray-600";
       }
     },
+    handleScroll() {
+      if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
+        this.loadMore();
+      }
+    },
+    loadMore() {
+      this.$emit("loadMore");
+    },
     resubmitMapRequest(id) {
       const map = this.offlineMaps.find((m) => m.id === id);
       if (map) {
@@ -330,15 +360,26 @@ export default {
   },
   computed: {
     currentLocaleName() {
-      const currentLocale = this.availableLocales.find(locale => locale.code === this.$i18n.locale);
-      return currentLocale ? currentLocale.name : '';
+      const currentLocale = this.availableLocales.find(
+        (locale) => locale.code === this.$i18n.locale,
+      );
+      return currentLocale ? currentLocale.name : "";
     },
     availableLocales() {
       return this.$i18n.locales;
     },
+    paginatedOfflineMaps() {
+      return this.offlineMaps;
+    },
     style() {
       return { ...overlayModal };
     },
+  },
+  mounted() {
+    window.addEventListener("scroll", this.handleScroll);
+  },
+  beforeDestroy() {
+    window.removeEventListener("scroll", this.handleScroll);
   },
 };
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -46,6 +46,7 @@ export default {
     async loadMore() {
       if (!this.nextCursor || this.isLoading) return;
 
+      // To avoid multiple requests at the same time
       this.isLoading = true;
 
       try {
@@ -58,7 +59,7 @@ export default {
           this.offlineMaps.push(...response.offlineMaps);
           this.nextCursor = response.nextCursor;
         } else {
-          this.nextCursor = null; // No more data to load
+          this.nextCursor = null;
         }
       } catch (error) {
         console.error("Error fetching more data:", error);


### PR DESCRIPTION
## Goal

Closes #29. The goal here is to implement cursor-based database pagination on the back end, and scroll-based loading to trigger more requests to load to the page.

## What I changed

* Modified `fetchDataFromTable()` to take a limit and cursor parameter, and query based on `id` (the table's primary key).
* Modified the API endpoint to set a default limit of 6, and pass `nextCursor` in the response, which the client can use to request the next set of records by passing it as the cursor parameter in the subsequent request.
* Data is now sorted based on `id` in descending, hence the `sortByDate()` function was removed as it is no longer necessary to figure out sort order based on timestamp.
* Added an async method `loadMore()` to index.vue to request more offline maps data based on `nextCursor` index, and push these to `offlineMaps` which is passed to MapDashboard as a prop.
* For the MapDashboard component, adopted a scroll-based loading approach (similar to GCV Gallery) to emit a request to upstream `loadMore()` method.