### PR TITLE
Add `format` option to UI and map request

### DIFF
--- a/components/GenerateMap/MapSidebar.vue
+++ b/components/GenerateMap/MapSidebar.vue
@@ -32,6 +32,7 @@ const form = reactive({
   planetMonthYear: calculateMaxPlanetMonthYear(),
   maxZoom: 8,
   estimatedTiles: 0,
+  format: "mbtiles",
 });
 
 const fetchMapStyles = () => {
@@ -332,6 +333,28 @@ watch(
           class="code-block"
           @keydown.prevent
         />
+      </div>
+
+      <div class="form-group">
+        <label for="format">
+          {{ $t("format") }}
+          <span class="text-red-600">*</span>
+        </label>
+        <div class="flex items-center space-x-6">
+          <div>
+            <input
+              type="radio"
+              id="mbtiles"
+              value="mbtiles"
+              v-model="form.format"
+            />
+            <label for="mbtiles" class="ml-1.25">MBTiles</label>
+          </div>
+          <div>
+            <input type="radio" id="smp" value="smp" v-model="form.format" />
+            <label for="smp" class="ml-1.25">Styled Map Package (SMP)</label>
+          </div>
+        </div>
       </div>
 
       <div v-if="form.maxZoom && form.selectedBounds">

--- a/lang/en.json
+++ b/lang/en.json
@@ -15,6 +15,7 @@
   "failed": "Failed",
   "fileSize": "File Size",
   "finishedOn": "Finished on",
+  "format": "Format",
   "generateMap": "Generate Map",
   "generateOfflineMap": "Generate Offline Map",
   "includeOSMData": "Include OSM Data (labels not shown)",

--- a/lang/es.json
+++ b/lang/es.json
@@ -15,6 +15,7 @@
   "failed": "Fallido",
   "fileSize": "Tamaño del archivo",
   "finishedOn": "Terminado en",
+  "format": "Formato",
   "generateMap": "Generar mapa",
   "generateOfflineMap": "Generar mapa offline",
   "includeOSMData": "Incluir datos OSM (etiquetas no mostradas)",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -15,6 +15,7 @@
   "failed": "Mislukt",
   "fileSize": "Bestandsgrootte",
   "finishedOn": "Voltooid op",
+  "format": "Formaat",
   "generateMap": "Kaart genereren",
   "generateOfflineMap": "Offline kaart genereren",
   "includeOSMData": "OSM-gegevens opnemen (labels niet getoond)",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -15,6 +15,7 @@
   "failed": "Falhou",
   "fileSize": "Tamanho do arquivo",
   "finishedOn": "Terminado em",
+  "format": "Formato",
   "generateMap": "Gerar mapa",
   "generateOfflineMap": "Gerar mapa offline",
   "includeOSMData": "Incluir dados OSM (rótulos não mostrados)",

--- a/pages/map.vue
+++ b/pages/map.vue
@@ -51,6 +51,7 @@ const handleMapRequest = async (formData) => {
     style: formData.selectedStyle,
     openstreetmap: formData.openstreetmap ?? false,
     number_of_tiles: formData.estimatedTiles,
+    format: formData.format,
     created_at: new Date(),
   };
 

--- a/server/database/dbOperations.ts
+++ b/server/database/dbOperations.ts
@@ -44,6 +44,7 @@ const createMapRequestTable = async (
       filename TEXT,
       file_location TEXT,
       file_size TEXT,
+      format TEXT,
       thumbnail_filename TEXT,
       status TEXT,
       error_message TEXT,

--- a/server/messageQueue/azure.ts
+++ b/server/messageQueue/azure.ts
@@ -16,6 +16,7 @@ export async function publishToAzureStorageQueue(
     planet_monthly_visual: string;
     style: string;
     apiKey: string;
+    format: string;
   },
 ) {
   const {
@@ -58,6 +59,7 @@ export async function publishToAzureStorageQueue(
           outputDir: offlineMapsPath,
         }),
     ...(message.apiKey && { apiKey: message.apiKey }),
+    ...(message.format && { format: message.format }),
     thumbnail: false,
   };
 

--- a/server/types.ts
+++ b/server/types.ts
@@ -43,5 +43,6 @@ export interface MapRequest {
   error_message: string | null;
   work_begun: Date | null;
   work_ended: Date | null;
+  format: string | null;
   thumbnail_filename: string | null;
 }


### PR DESCRIPTION
## Goal

[This pending PR in `mapgl-tile-renderer`](https://github.com/ConservationMetrics/mapgl-tile-renderer/pull/63) will make it possible to export a tileset as a Styled Map Package. 

Here, I am making it possible for a user to select a `format` option (mbtiles or smp) in the MapPacker front end.

## Screenshots

![image](https://github.com/user-attachments/assets/70d40192-817f-4a53-8f94-8bff2062f595)

## What I changed

* Added a radio button selection for Format to `MapSidebar`
* Ensured `format` parameter is added to the map request data schema in all relevant places (db schema, ASQ, etc).
