### PR TITLE
Refresh Postgres connection when lost

### DIFF
--- a/server/api/data.ts
+++ b/server/api/data.ts
@@ -1,5 +1,5 @@
 import { defineEventHandler, getQuery, send, sendError, H3Event } from "h3";
-import { db } from "@/server/index";
+import { getDatabaseConnection } from "@/server/database/dbConnection";
 import { fetchData } from "../database/dbOperations";
 
 export default defineEventHandler(async (event: H3Event) => {
@@ -10,6 +10,8 @@ export default defineEventHandler(async (event: H3Event) => {
   const query = getQuery(event);
   const limit = parseInt(query.limit as string) || 6;
   const cursor = query.cursor ? parseInt(query.cursor as string) : null;
+
+  const db = await getDatabaseConnection();
 
   try {
     const { data } = await fetchData(db, dbTable, limit, cursor);

--- a/server/api/maprequest.ts
+++ b/server/api/maprequest.ts
@@ -1,5 +1,5 @@
 import { defineEventHandler, readBody, send, sendError, H3Event } from "h3";
-import { db } from "@/server/index";
+import { getDatabaseConnection } from "@/server/database/dbConnection";
 import {
   insertDataIntoTable,
   updateDatabaseMapRequest,
@@ -21,6 +21,8 @@ export default defineEventHandler(async (event: H3Event) => {
   if (data.style === "mapbox-custom" || data.style === "mapbox-streets") {
     data.style = "mapbox";
   }
+
+  const db = await getDatabaseConnection();
 
   try {
     // If it's a new request, insert data into the database

--- a/server/database/dbConfig.ts
+++ b/server/database/dbConfig.ts
@@ -1,0 +1,27 @@
+export const getConfig = () => {
+  const {
+    database,
+    dbHost,
+    dbUser,
+    dbPassword,
+    dbPort,
+    dbSsl,
+    // eslint-disable-next-line no-undef
+  } = useRuntimeConfig() as unknown as {
+    database: string;
+    dbHost: string;
+    dbUser: string;
+    dbPassword: string;
+    dbPort: string;
+    dbSsl: boolean;
+  };
+
+  return {
+    database,
+    dbHost,
+    dbUser,
+    dbPassword,
+    dbPort,
+    dbSsl,
+  };
+};

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,42 +1,13 @@
-import setupDatabaseConnection from "./database/dbConnection";
-import { type DatabaseConnection } from "./types";
-
-let db: DatabaseConnection;
-
-const {
-  database,
-  dbHost,
-  dbUser,
-  dbPassword,
-  dbPort,
-  dbSsl,
-  // eslint-disable-next-line no-undef
-} = useRuntimeConfig() as unknown as {
-  database: string;
-  dbHost: string;
-  dbUser: string;
-  dbPassword: string;
-  dbPort: string;
-  dbSsl: boolean;
-};
+import { refreshDatabaseConnection } from "./database/dbConnection";
 
 export default async () => {
   try {
-    db = await setupDatabaseConnection(
-      database,
-      dbHost,
-      dbUser,
-      dbPassword,
-      dbPort,
-      dbSsl,
-    );
+    await refreshDatabaseConnection();
   } catch (error) {
     if (error instanceof Error) {
-      throw new Error(`Failed to connect to ${database}:`, error);
+      throw new Error(`Failed to connect to database: ${error.message}`);
     } else {
       console.error("Unknown error connecting to database:", error);
     }
   }
 };
-
-export { db };


### PR DESCRIPTION
## Goal

The goal here is to refresh a Postgres database connection when discovered to have been lost. Changes similar to https://github.com/ConservationMetrics/guardianconnector-explorer/pull/82, only even more simplified as map-packer does not have a need to connect to two databases (configDb and db).